### PR TITLE
Feat/db and integrations setup

### DIFF
--- a/env.example
+++ b/env.example
@@ -21,7 +21,6 @@ STRIPE_WEBHOOK_SECRET="whsec_..."
 # PostHog Analytics
 POSTHOG_KEY="phc_..."
 NEXT_PUBLIC_POSTHOG_KEY="phc_..."
-# optionally override host
 # NEXT_PUBLIC_POSTHOG_HOST="https://app.posthog.com"
 
 # AI Models
@@ -32,7 +31,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 # Redis (for BullMQ)
 REDIS_URL="redis://localhost:6379"
 
-# Email
+# Email (for Email provider if enabled)
 EMAIL_FROM="noreply@yourdomain.com"
 SMTP_HOST="smtp.gmail.com"
 SMTP_USER="your-email@gmail.com"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,8 @@ model User {
   draftReplies     DraftReply[] @relation("DraftReplyCreatedBy")
   publishedReplies Reply[]      @relation("ReplyPublishedBy")
   auditLogs        AuditLog[]   @relation("AuditLogActor")
+  accounts         Account[]
+  sessions         Session[]
 }
 
 model Org {
@@ -243,4 +245,38 @@ model ApiKey {
   secret    String   @unique
   createdAt DateTime @default(now())
   org       Org      @relation(fields: [orgId], references: [id])
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model Account {
+  id                String  @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?
+  session_state     String?
+  user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
 }

--- a/src/app/api/integrations/google/callback/route.ts
+++ b/src/app/api/integrations/google/callback/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GoogleBusinessProvider } from '@/lib/providers/google'
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const code = url.searchParams.get('code')
+  if (!code) {
+    return NextResponse.json({ error: 'Missing code' }, { status: 400 })
+  }
+
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    const signin = new URL('/auth/signin', process.env.NEXTAUTH_URL)
+    return NextResponse.redirect(signin)
+  }
+
+  const provider = new GoogleBusinessProvider('')
+  const { accessToken, refreshToken, expiresAt, scopes } = await provider.exchangeCode(code)
+
+  // ensure the user has an org
+  const userId = (session.user as any).id as string
+  let membership = await prisma.membership.findFirst({ where: { userId } })
+  let orgId: string
+  if (!membership) {
+    const org = await prisma.org.create({ data: { name: `${session.user?.name || 'My'} Organization` } })
+    await prisma.membership.create({ data: { userId, orgId: org.id, role: 'OWNER' } })
+    orgId = org.id
+  } else {
+    orgId = membership.orgId
+  }
+
+  await prisma.integration.create({
+    data: {
+      orgId,
+      provider: 'GOOGLE',
+      accessToken,
+      refreshToken,
+      expiresAt: expiresAt || undefined,
+      scopes,
+    },
+  })
+
+  const redirect = new URL('/integrations?connected=google', process.env.NEXTAUTH_URL)
+  return NextResponse.redirect(redirect)
+}

--- a/src/app/api/integrations/google/callback/route.ts
+++ b/src/app/api/integrations/google/callback/route.ts
@@ -21,8 +21,12 @@ export async function GET(req: Request) {
   const { accessToken, refreshToken, expiresAt, scopes } = await provider.exchangeCode(code)
 
   // ensure the user has an org
-  const userId = (session.user as any).id as string
-  let membership = await prisma.membership.findFirst({ where: { userId } })
+  const userId = typeof session.user?.id === 'string' ? session.user.id : undefined
+  if (!userId) {
+    return NextResponse.json({ error: 'No user id on session' }, { status: 400 })
+  }
+
+  const membership = await prisma.membership.findFirst({ where: { userId } })
   let orgId: string
   if (!membership) {
     const org = await prisma.org.create({ data: { name: `${session.user?.name || 'My'} Organization` } })

--- a/src/app/api/integrations/google/start/route.ts
+++ b/src/app/api/integrations/google/start/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { GoogleBusinessProvider } from '@/lib/providers/google'
+
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    const signin = new URL('/auth/signin', process.env.NEXTAUTH_URL)
+    return NextResponse.redirect(signin)
+  }
+  const provider = new GoogleBusinessProvider('')
+  const authUrl = provider.getAuthUrl()
+  return NextResponse.redirect(authUrl)
+}

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link'
+import { authOptions } from '@/lib/auth'
+import { getServerSession } from 'next-auth'
+import { prisma } from '@/lib/db'
+
+export default async function IntegrationsPage() {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 p-6">
+        <div className="w-full max-w-md space-y-4 rounded-lg border bg-white p-6 shadow-sm text-center">
+          <h1 className="text-2xl font-semibold text-gray-900">Integrations</h1>
+          <p className="text-sm text-gray-600">Please sign in to manage integrations.</p>
+          <Link href="/auth/signin" className="inline-flex items-center justify-center rounded-md bg-black px-4 py-2 text-white">
+            Sign in
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  const userId = (session.user as any).id as string
+  const membership = await prisma.membership.findFirst({ where: { userId } })
+  const orgId = membership?.orgId
+  const integrations = orgId ? await prisma.integration.findMany({ where: { orgId } }) : []
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <main className="max-w-3xl mx-auto py-10 px-4">
+        <h1 className="text-3xl font-bold text-gray-900 mb-6">Integrations</h1>
+        <div className="mb-8">
+          <div className="rounded-lg border bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold mb-2">Google Business Profile</h2>
+            <p className="text-sm text-gray-600 mb-4">Connect to fetch reviews and publish owner replies.</p>
+            <Link href="/api/integrations/google/start" className="inline-flex items-center justify-center rounded-md bg-black px-4 py-2 text-white">
+              Connect Google
+            </Link>
+          </div>
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold mb-3">Connected Integrations</h2>
+          {integrations.length === 0 ? (
+            <p className="text-sm text-gray-600">No integrations yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {integrations.map((i) => (
+                <li key={i.id} className="rounded border bg-white p-4 text-sm">
+                  <div className="flex items-center justify-between">
+                    <span>{i.provider}</span>
+                    <span className="text-gray-500">Scopes: {i.scopes?.join(', ')}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/integrations/page.tsx
+++ b/src/app/integrations/page.tsx
@@ -19,8 +19,8 @@ export default async function IntegrationsPage() {
     )
   }
 
-  const userId = (session.user as any).id as string
-  const membership = await prisma.membership.findFirst({ where: { userId } })
+  const userId = typeof session.user?.id === 'string' ? session.user.id : undefined
+  const membership = userId ? await prisma.membership.findFirst({ where: { userId } }) : null
   const orgId = membership?.orgId
   const integrations = orgId ? await prisma.integration.findMany({ where: { orgId } }) : []
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,9 +1,12 @@
 import { NextAuthOptions, type DefaultSession } from 'next-auth'
 import GoogleProvider from 'next-auth/providers/google'
+import { PrismaAdapter } from '@auth/prisma-adapter'
+import { prisma } from './db'
 
 type SessionUser = DefaultSession['user'] & { id?: string }
 
 export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
   providers: [
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID!,
@@ -19,8 +22,6 @@ export const authOptions: NextAuthOptions = {
     },
     jwt: async ({ token }) => {
       if (token.sub) {
-        // augment token with id for convenience
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (token as unknown as { id?: string }).id = token.sub
       }
       return token


### PR DESCRIPTION
Summary

Add NextAuth Prisma models (Account, Session, VerificationToken) and enable PrismaAdapter for persistent users/sessions.
Implement Google integration flow:
/api/integrations/google/start: redirects to Google OAuth consent
/api/integrations/google/callback: exchanges code, persists Integration for the user’s Org
Add /integrations page with a Connect Google button and list of current integrations.
Minor lint/type fixes and PostHog/init + CSS cleanup from previous work are retained.